### PR TITLE
One line fix to avoid adding an ellipsis to elements that don't need to be truncated.

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -231,7 +231,9 @@
         }
         else {
             var height = getMaxHeight(clampValue);
-            truncate(getLastChild(element), height);
+            if (height <= element.clientHeight) {
+                truncate(getLastChild(element), height);
+            }
         }
     }
 


### PR DESCRIPTION
Sometimes the texts that I wanted to clamp (pulled from a DB) are short enough to fit in the available space. In that case, browsers that don't support webkitLineClamp were adding a superfluous ellipsis.

HTH.
Cheers,

  — n.
