### PR TITLE
don't append 'px' to opt.clamp. it already has it.

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -241,7 +241,7 @@
             sty.webkitLineClamp = clampValue;
 
             if (isCSSValue) {
-                sty.height = opt.clamp + 'px';
+                sty.height = opt.clamp;
             }
         }
         else {


### PR DESCRIPTION
if the clamp option is a CSS value, it's specified that the parameter be a string such as '35 px' so it doesn't need to be added again.
