### PR TITLE
Don't leak private getComputedStyle() to global window object

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -49,10 +49,13 @@
          * @returns {number}
          */
         function computeStyle(elem, prop) {
-            if (!win.getComputedStyle) {
-                win.getComputedStyle = function(el, pseudo) {
+            var getComputedStyle;
+            if (win.getComputedStyle) {
+                getComputedStyle = win.getComputedStyle;
+            } else {
+                getComputedStyle = function (el, pseudo) {
                     this.el = el;
-                    this.getPropertyValue = function(prop) {
+                    this.getPropertyValue = function (prop) {
                         var re = /(\-([a-z]){1})/g;
                         if (prop == 'float') prop = 'styleFloat';
                         if (re.test(prop)) {
@@ -66,7 +69,7 @@
                 }
             }
 
-            return win.getComputedStyle(elem, null).getPropertyValue(prop);
+            return getComputedStyle(elem, null).getPropertyValue(prop);
         }
 
         /**


### PR DESCRIPTION
Currently Clamp.js leaks the private fallback implementation of getComputedStyle() to the global window object. This does not play nice with other code, that does not expect the function to exist in IE8 and other old browsers. There should be no need to expose the inner function. This fix keeps the implementation private.
