### PR TITLE
avoid clamping if line height is still valid

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -246,7 +246,7 @@
         }
         else {
             var height = getMaxHeight(clampValue);
-            if (height <= element.clientHeight) {
+            if (height < element.clientHeight) {
                 clampedText = truncate(getLastChild(element), height);
             }
         }


### PR DESCRIPTION
 If we used firefox (or any other browser without native clamping), the last line was always clamped: it cuts of the last letter and appends e.g. the "..." even if theres plenty of space in that line. This is because the condition checks if the current line height is greater _or equal_ than the maximum allowed. So if the text is rendered in two lines (eg 2 x 10px) and the maximum allowed is the same, it still gets clamped. We removed the "or equal" from the condition so it only gets truncated if the rendered line height is too high and that works for us perfectly now.
