### PR TITLE
toggle classes for clamping in modern browsers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,4 +70,4 @@ Defaults to false.
 
 # Methods
 
-**toggle** Toggles the ".camp-styles" class
+**toggle** Toggles the ".clamp-styles" class

--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,13 @@ $clamp(myParagraph, {clamp: 'auto'});
 
 //Auto-clamp based on a fixed element height
 $clamp(myParagraph, {clamp: '35px'});
+
+// Toggle clamp class
+var clamped = $clamp(myParagraph, {clamp: 'auto'});
+// turn clamp off
+clamped.toggle();
+// turn clamp back on
+clamped.toggle();
 </pre>
 
 The $clamp method is the primary way of interacting with Clamp.js, and it takes two
@@ -60,3 +67,7 @@ is submitted in the array.
 **animate** _(Boolean)_. Silly little easter-egg that, when set to true, will animate
 removing individual characters from the end of the element until the content fits.
 Defaults to false.
+
+# Methods
+
+**toggle** Toggles the ".camp-styles" class

--- a/clamp.js
+++ b/clamp.js
@@ -222,6 +222,16 @@
             elem.nodeValue = str + opt.truncationChar;
         }
 
+        function _styleAdded(className) {
+            var styleAdded = false;
+            for (var s = 0, tag = document.head.querySelectorAll('style'); s < tag.length; s++) {
+                if (tag[s] && tag[s].innerHTML.indexOf(className) !== -1) {
+                    styleAdded = true;
+                    break;
+                }
+            }
+            return styleAdded;
+        }
 
 // CONSTRUCTOR ________________________________________________________________
 
@@ -234,15 +244,29 @@
 
         var clampedText;
         if (supportsNativeClamp && opt.useNativeClamp) {
-            sty.overflow = 'hidden';
-            sty.textOverflow = 'ellipsis';
-            sty.webkitBoxOrient = 'vertical';
-            sty.display = '-webkit-box';
-            sty.webkitLineClamp = clampValue;
-
+            var style = document.createElement('style');
+            var props = {
+                'overflow': 'hidden',
+                'text-overflow': 'ellipsis',
+                '-webkit-box-orient': 'vertical',
+                'display': '-webkit-box',
+                '-webkit-line-clamp': clampValue
+            };
             if (isCSSValue) {
-                sty.height = opt.clamp + 'px';
+                props.height = opt.clamp + 'px';
             }
+
+            var clampStyles = '';
+            for(var p in props) {
+                clampStyles += p + ':' + props[p] + ';';
+            }
+
+            style.innerHTML = '.clamp-styles {' + clampStyles + '}';
+
+            if (!_styleAdded('.clamp-styles')) {
+                document.head.appendChild(style);
+            }
+
         }
         else {
             var height = getMaxHeight(clampValue);
@@ -250,8 +274,22 @@
                 clampedText = truncate(getLastChild(element), height);
             }
         }
+
+        function toggle() {
+            var isClamped = element.className.indexOf('clamp-styles') !== -1;
+            if (isClamped) {
+                element.className = element.className.replace(/clamp\-styles/, '');
+            } else {
+                element.className += ' clamp-styles';
+            }
+            return isClamped;
+        }
+
+        // add clamp-styles class
+        toggle();
         
         return {
+            toggle: toggle,
             'original': originalText,
             'clamped': clampedText
         }


### PR DESCRIPTION
I needed to toggle the clamp for a collapsible plugin. With toggle it will toggle a `.clamp-styles` class instead of adding styles directly to the element.
