### PR TITLE
Fix initial height check

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -246,7 +246,7 @@
         }
         else {
             var height = getMaxHeight(clampValue);
-            if (height <= element.clientHeight) {
+            if (height < element.clientHeight) {
                 clampedText = truncate(getLastChild(element), height);
             }
         }


### PR DESCRIPTION
The initial height check truncated text if the original
height was greater than or equal to the max allowable height,
where it should only truncate if the original height is
strictly greater than the max allowable height.

This change makes the initial check consistent with the
exit condition check, which checks if the current height
is less than or equal to the max allowable height.
