### PR TITLE
Update clamp.js

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -246,7 +246,7 @@
         }
         else {
             var height = getMaxHeight(clampValue);
-            if (height <= element.clientHeight) {
+            if (height < element.clientHeight) {
                 clampedText = truncate(getLastChild(element), height);
             }
         }


### PR DESCRIPTION
when height is based on line-height times clamp _<=_ causes unwanted truncate
